### PR TITLE
[Security] Add 2-day minimum release age cooldown (incident-51987)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=2


### PR DESCRIPTION
## Summary

- Adds `min-release-age=2` to `.npmrc` to configure npm to refuse packages published less than 2 days ago during lockfile generation
- Part of the incident-51987 security campaign to add release age cooldowns across DataDog repositories
- Requires npm >= 11.10.0; older npm versions silently ignore this setting

## Test plan

- [ ] Verify `.npmrc` is picked up by `npm install` (run `npm config list` in repo root)
- [ ] Confirm no existing workflows are broken by this addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)