### PR TITLE
fix: memoize tracingChannel(name) to stabilize sub-channel identity

### DIFF
--- a/dc-polyfill.js
+++ b/dc-polyfill.js
@@ -24,6 +24,11 @@ if (!checks.hasChannelStoreMethods()) {
 
 if (!checks.hasTracingChannel()) {
   dc = require('./patch-tracing-channel.js')(dc);
+} else if (checks.hasGarbageCollectionBug()) {
+  // Native tracingChannel exists but the underlying channel() registry is
+  // unstable; memoize tracingChannel by name so its sub-channel identities stay
+  // stable across calls.
+  dc = require('./patch-tracing-channel-stable-identity.js')(dc);
 }
 
 if (checks.hasSyncUnsubscribeBug()) {

--- a/patch-tracing-channel-stable-identity.js
+++ b/patch-tracing-channel-stable-identity.js
@@ -1,0 +1,36 @@
+// Make dc.tracingChannel(name) return a stable TracingChannel object per name
+// on Node versions that have a native tracingChannel BUT also have the
+// channel-registry GC bug (Node 16.17–16.x, 18.7–18.x, 20.0–20.5).
+//
+// On those versions the native tracingChannel(name) constructor calls Node's
+// internal channel() to build its five sub-channels (start, end, asyncStart,
+// asyncEnd, error). Because the underlying registry can return a brand-new
+// Channel object for the same name on a subsequent call, two `tracingChannel(name)`
+// invocations can end up with different sub-channel identities. Subscribers
+// attached to one TracingChannel's sub-channels then miss publishes from
+// another TracingChannel's sub-channels for the same name.
+//
+// patch-garbage-collection-bug.js memoizes `dc.channel(name)`, but
+// native tracingChannel bypasses that wrapper — it goes through Node's
+// internal channel() directly. Memoizing the TracingChannel by name closes
+// the gap: same name returns the same TC (and therefore the same sub-channels)
+// for the lifetime of the process.
+
+module.exports = function (unpatched) {
+  const dc = { ...unpatched };
+  const original = dc.tracingChannel;
+  const byName = new Map();
+
+  dc.tracingChannel = function (nameOrChannels) {
+    if (typeof nameOrChannels !== 'string') {
+      // Object form — caller is providing explicit sub-channels; passthrough.
+      return original.call(this, nameOrChannels);
+    }
+    if (byName.has(nameOrChannels)) return byName.get(nameOrChannels);
+    const tc = original.call(this, nameOrChannels);
+    byName.set(nameOrChannels, tc);
+    return tc;
+  };
+
+  return dc;
+};

--- a/test/tracing-channel-stable-identity.spec.js
+++ b/test/tracing-channel-stable-identity.spec.js
@@ -1,0 +1,90 @@
+const test = require('tape');
+const patch = require('../patch-tracing-channel-stable-identity.js');
+
+// Simulate the failure mode this patch addresses: native tracingChannel
+// returns a fresh TracingChannel object on every string-form call (because
+// Node's underlying channel() registry returned different sub-channel
+// objects). The patch's job is to memoize TracingChannel objects by name
+// so callers see a stable identity per name.
+function mockUnpatched() {
+  const calls = { count: 0 };
+  function tracingChannel(nameOrChannels) {
+    calls.count++;
+    if (typeof nameOrChannels === 'string') {
+      // Mimic the native behavior of building fresh sub-channels per call,
+      // each with their own identity.
+      return {
+        _name: nameOrChannels,
+        _instanceId: calls.count,
+        start: { _name: `${nameOrChannels}:start`, _instanceId: calls.count },
+        end: { _name: `${nameOrChannels}:end`, _instanceId: calls.count },
+        asyncStart: { _name: `${nameOrChannels}:asyncStart`, _instanceId: calls.count },
+        asyncEnd: { _name: `${nameOrChannels}:asyncEnd`, _instanceId: calls.count },
+        error: { _name: `${nameOrChannels}:error`, _instanceId: calls.count },
+      };
+    }
+    return { _passthrough: true, channels: nameOrChannels };
+  }
+  return { tracingChannel, calls };
+}
+
+test('tracing-channel stable-identity patch: tracingChannel(name) returns same TracingChannel across calls', t => {
+  const { tracingChannel, calls } = mockUnpatched();
+  const dc = patch({ tracingChannel });
+
+  const a = dc.tracingChannel('foo');
+  const b = dc.tracingChannel('foo');
+  const c = dc.tracingChannel('foo');
+
+  t.strictEqual(a, b, 'second call returns same TracingChannel');
+  t.strictEqual(b, c, 'third call returns same TracingChannel');
+  t.strictEqual(a.start, b.start, 'sub-channel start identity stable');
+  t.strictEqual(a.end, b.end, 'sub-channel end identity stable');
+  t.strictEqual(a.asyncStart, b.asyncStart, 'sub-channel asyncStart identity stable');
+  t.strictEqual(a.asyncEnd, b.asyncEnd, 'sub-channel asyncEnd identity stable');
+  t.strictEqual(a.error, b.error, 'sub-channel error identity stable');
+
+  const callsAfterMemoization = calls.count;
+  dc.tracingChannel('foo');
+  dc.tracingChannel('foo');
+  t.equal(calls.count, callsAfterMemoization,
+    'memoized lookups do not re-invoke the underlying tracingChannel()');
+
+  t.end();
+});
+
+test('tracing-channel stable-identity patch: distinct names get distinct TracingChannels', t => {
+  const { tracingChannel } = mockUnpatched();
+  const dc = patch({ tracingChannel });
+
+  const foo = dc.tracingChannel('foo');
+  const bar = dc.tracingChannel('bar');
+
+  t.notStrictEqual(foo, bar, 'different names return different TracingChannels');
+  t.notStrictEqual(foo.start, bar.start, 'different names have different sub-channels');
+  t.strictEqual(dc.tracingChannel('foo'), foo, 'foo memoization holds');
+  t.strictEqual(dc.tracingChannel('bar'), bar, 'bar memoization holds');
+  t.end();
+});
+
+test('tracing-channel stable-identity patch: object form is passthrough (not memoized)', t => {
+  const { tracingChannel } = mockUnpatched();
+  const dc = patch({ tracingChannel });
+
+  const channels = {
+    start: { _name: 'custom:start' },
+    end: { _name: 'custom:end' },
+    asyncStart: { _name: 'custom:asyncStart' },
+    asyncEnd: { _name: 'custom:asyncEnd' },
+    error: { _name: 'custom:error' },
+  };
+
+  const a = dc.tracingChannel(channels);
+  const b = dc.tracingChannel(channels);
+
+  // Object form bypasses memoization — caller is providing explicit channels.
+  t.notStrictEqual(a, b, 'object form returns a fresh wrapper each time');
+  t.ok(a._passthrough, 'first call passes through');
+  t.ok(b._passthrough, 'second call passes through');
+  t.end();
+});


### PR DESCRIPTION
### What does this PR do?

Wraps `dc.tracingChannel` to memoize TracingChannel objects by name on the narrow window of Node versions where native `tracingChannel()` exists but the underlying `channel()` registry doesn't return stable identity per name (Node 16.17–16.x, 18.7–18.x, 20.0–20.5).

```diff
+ } else if (checks.hasGarbageCollectionBug()) {
+   // Native tracingChannel exists but the underlying channel() registry is
+   // unstable; memoize tracingChannel by name so its sub-channel identities stay
+   // stable across calls.
+   dc = require('./patch-tracing-channel-stable-identity.js')(dc);
  }
```

### Motivation

Companion to [#27](https://github.com/DataDog/dc-polyfill/pull/27), which memoizes `dc.channel(name)` to give a stable Channel identity per name. That patch covers consumers of bare `dc.channel(...)`, but it has a coverage gap:

- The polyfilled tracingChannel ([patch-tracing-channel.js](https://github.com/DataDog/dc-polyfill/blob/main/patch-tracing-channel.js)) inherits the memoization for free — its `TracingChannel` constructor calls `dc.channel(...)` internally (which is the patched/memoized version).
- **Native tracingChannel does not.** When Node's native `tracingChannel(name)` constructs its five sub-channels (\`start\`, \`end\`, \`asyncStart\`, \`asyncEnd\`, \`error\`), it calls Node's *internal* \`channel()\` function — bypassing the JS-level wrapper installed by [patch-garbage-collection-bug.js](https://github.com/DataDog/dc-polyfill/blob/main/patch-garbage-collection-bug.js).

The result: on Node versions where tracingChannel is native AND the channel registry has the GC bug, two `tracingChannel('foo')` calls can produce two different `TracingChannel` objects with two different sets of sub-channels. A subscriber attached to one TC's sub-channels misses publishes from the other TC's sub-channels for the same name. Same shape of failure as the bare-channel case in #27, just one layer up.

### Why this fix lives here, not upstream in Node

Same reasoning as [#27](https://github.com/DataDog/dc-polyfill/pull/27):

- The underlying registry instability is a Node bug, fixed in Node 20.6+ (referenced by [nodejs/node#47520](https://github.com/nodejs/node/pull/47520) in this repo's existing comment).
- Node 18 reached EOL on 2025-04-30 — backports to EOL'd lines effectively only happen for security CVEs.
- Node 16 has been EOL since 2023-09-11.
- This whole patch is gated on \`hasTracingChannel() && hasGarbageCollectionBug()\`, narrows naturally as consumers drop affected lines, and becomes inert/deletable alongside other GC-bug workarounds.

### Strategy

Memoize the `TracingChannel` object by name. Same name returns the same TC for the lifetime of the process, with the same sub-channels captured at first-call construction time. The TC's own references to its sub-channels keep them alive — even if Node's internal registry would otherwise hand out new ones on subsequent direct lookups, the memoized TC keeps using the original set.

Object form (caller-provided explicit sub-channels) is passthrough — the caller is taking responsibility for sub-channel identity.

### Verification

- New regression test ([test/tracing-channel-stable-identity.spec.js](https://github.com/DataDog/dc-polyfill/blob/brian.marks/memoize-tracing-channel/test/tracing-channel-stable-identity.spec.js)) injects a mock `tracingChannel` whose string-form call returns a fresh TC each invocation (simulating the failure mode). 15/15 assertions pass with the patch; would fail on `main`. Covers identity stability, sub-channel identity stability, per-name memoization, and the object-form passthrough.
- Full existing test suite passes on Node 18.20.8 (\`./test.sh\`: 27/27 suites).
- Lint clean (\`npm run lint\`).

### Additional Notes

- The map is bounded by the number of unique tracingChannel names a process uses — a small fixed set per consumer.
- Doesn't affect Node 20.6+ (no GC bug → patch not applied) or Node < 16.17 / < 18.7 (no native tracingChannel → polyfill is applied instead, which already handles this correctly via memoized \`dc.channel\`).
- Strengthens the contract callers expect: \`tracingChannel(name)\` returns *the* TracingChannel for *name*. Doesn't weaken anything.
- Defense-in-depth alongside #27 — if dd-trace's stress repro starts hitting the native-tracingChannel sub-channel path under different conditions, this closes the gap rather than papering over it via additional bare-channel memoization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)